### PR TITLE
Button for credits management not to be in My Credits [FE]

### DIFF
--- a/public/app/accounting/partials/statement.html
+++ b/public/app/accounting/partials/statement.html
@@ -15,7 +15,7 @@
         md-open="menu.open" 
         md-direction="up" 
         class="md-scale ora-fab"
-        ng-if="statement && ctrl.isNewTransactionsAllowed()">
+        ng-if="statement && ctrl.isNewTransactionsAllowed() && currentTab === 0">
     <md-fab-trigger>
         <md-button aria-label="Account Menu" class="md-fab md-warn md-hue-1">
             <md-icon md-svg-icon="add"></md-icon>


### PR DESCRIPTION
As a user I do *not* want to see the red button for credits management in the "My Credits" tab, in order not to get confused as to what it can do.

https://www.pivotaltracker.com/story/show/145680425